### PR TITLE
Fix: Fix `Execute-Command.Tests.ps1` undefined `$global:LASTEXITCODE` in begining of test

### DIFF
--- a/src/Generate-DockerImageVariantsHelpers/public/Execute-Command.Tests.ps1
+++ b/src/Generate-DockerImageVariantsHelpers/public/Execute-Command.Tests.ps1
@@ -6,6 +6,10 @@ Describe "Execute-Command" -Tag 'Unit' {
 
     Context 'Behavior' {
 
+        BeforeEach {
+            $global:LASTEXITCODE = 0
+        }
+        
         It 'Executes expressions' {
             Execute-Command -Command 123 | Should -Be 123
             Execute-Command -Command { 123 } | Should -Be 123


### PR DESCRIPTION
This might be a Pester v4 bug. It should not be cleaning out the `$LASTEXITCODE` global variable.
