### PR TITLE
Fix: Omit `Set-DockerImageVariantsVersions -DoubleNewlines` for normal `versions.json` newlines

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ Get-DockerImageVariantsVersions
 
 # Set generate/definitions/versions.json
 Set-DockerImageVariantsVersions -Versions @( '0.1.0', '0.2.0' )
-Set-DockerImageVariantsVersions -Versions @( '0.1.0', '0.2.0' ) -DoubleNewlines
 
 # Execute commands
 { git status } | Execute-Command -ErrorAction Stop

--- a/src/Generate-DockerImageVariantsHelpers/public/Update-DockerImageVariantsVersions.ps1
+++ b/src/Generate-DockerImageVariantsHelpers/public/Update-DockerImageVariantsVersions.ps1
@@ -38,7 +38,7 @@ function Update-DockerImageVariantsVersions {
                 Get-DockerImageVariantsVersions
             )
             if (!$DryRun) {
-                Set-DockerImageVariantsVersions -Versions $versions -DoubleNewlines
+                Set-DockerImageVariantsVersions -Versions $versions
                 if ($PR) {
                     $prs += New-DockerImageVariantsPR -Version $vc['to'] -Verb add
                 }
@@ -54,7 +54,7 @@ function Update-DockerImageVariantsVersions {
                 }
             }
             if (!$DryRun) {
-                Set-DockerImageVariantsVersions -Versions $versions -DoubleNewlines
+                Set-DockerImageVariantsVersions -Versions $versions
                 if ($PR) {
                     $prs += New-DockerImageVariantsPR -Version $vc['from'] -VersionNew $vc['to'] -Verb update
                 }


### PR DESCRIPTION
Since `Automerge-DockerImageVariantsPR` and `Update-DockerImageVariantsVersions -PR -AutoMergeQueue` has been added in #28 and #29, when PRs are merged one after another there's no need for double newlines to prevent merge conflicts. Hence #26 may be reverted.
