### PR TITLE
Fix: Add missing `Content-Type` key in `Invoke-RestMethod -Headers`

### DIFF
--- a/src/Generate-DockerImageVariantsHelpers/public/Automerge-DockerImageVariantsPR.ps1
+++ b/src/Generate-DockerImageVariantsHelpers/public/Automerge-DockerImageVariantsPR.ps1
@@ -17,6 +17,7 @@ function Automerge-DockerImageVariantsPR {
             'Accept' = 'application/vnd.github+json'
             'Authorization' = "Bearer $env:GITHUB_TOKEN"
             'X-GitHub-Api-Version' = '2022-11-28'
+            'Content-Type' = 'application/json'
         }
         "Will automerge PR" | Write-Host
         if (!$WhatIfPreference) {

--- a/src/Generate-DockerImageVariantsHelpers/public/New-Release.ps1
+++ b/src/Generate-DockerImageVariantsHelpers/public/New-Release.ps1
@@ -19,6 +19,7 @@ function New-Release {
                 'Accept' = 'application/vnd.github+json'
                 'Authorization' = "Bearer $env:GITHUB_TOKEN"
                 'X-GitHub-Api-Version' = '2022-11-28'
+                'Content-Type' = 'application/json'
             }
             $owner = ({ git remote get-url origin } | Execute-Command) -replace 'https://github.com/([^/]+)/([^/]+)', '$1'
             $project = ({ git remote get-url origin } | Execute-Command) -replace 'https://github.com/([^/]+)/([^/]+)', '$2' -replace '\.git$', ''


### PR DESCRIPTION
Fixes Powershell 7.4 which now expects either `Invoke-RestMethod -Headers @{ 'Content-type' = '...' }`  or `-ContentType` to be populated, or it would error with `The given key 'Content-Type' was not present in the dictionary.`. See:
- https://github.com/theohbrothers/docker-kubectl/actions/runs/7909389274/job/21590330176#step:3:1516
- https://github.com/theohbrothers/docker-terraform/actions/runs/7837925330/job/21388510328#step:3:636
